### PR TITLE
Using HDF5 as the data storage format

### DIFF
--- a/Globalvar.f90
+++ b/Globalvar.f90
@@ -1,6 +1,6 @@
 module globalvar
 !====================================================================
-! This is the global variables for the PIP code. 
+! This is the global variables for the PIP code.
 ! Author A.Hillier
 ! First version - 2013/04/23
 ! Second version - 2013/06/02
@@ -17,7 +17,7 @@ use HDF5
   double precision,allocatable,save ::U_m(:,:,:,:),U_h(:,:,:,:)
 
 !Magnetic field at cell-face
-  
+
 !other variables
   double precision,allocatable,save ::kap(:,:,:),mu(:,:,:),eta(:,:,:)
   double precision,allocatable,save::ac(:,:,:),xi_n(:,:,:),GM_rec(:,:,:),Gm_ion(:,:,:)
@@ -35,7 +35,7 @@ use HDF5
 
 ! for numerical calculation
   integer,save::flag_mhd,flag_pip
-  integer,save::flag_sch,flag_hll,flag_artvis,no_advection  
+  integer,save::flag_sch,flag_hll,flag_artvis,no_advection
   integer,save::flag_resi,flag_visc,flag_heat,flag_grav,flag_amb
   integer,save::flag_b_stg,flag_divb,flag_pip_imp
   integer,save::flag_cc,flag_ex,flag_restart,flag_debug,flag_ps
@@ -57,7 +57,7 @@ use HDF5
   double precision,save :: cmax
 ! Radiative losses
   integer,save :: flag_rad
-  
+
 !for coordinate system
   integer,save::ix,jx,kx,nvar_h,nvar_m,margin(3),ndim,ig(3)
 ! marginz is set to 0 for 2d to let all the 3d codes that use margin work
@@ -66,7 +66,7 @@ use HDF5
   double precision,save ::time,dt,dtout,dt_cnd,start_t
   integer,save:: flag_stop,flag_time,t_order,s_order,total_iter
   integer,save:: flag_hc_test,nmax=500000000
-  
+
 !for output
   double precision,save:: tend ! time at which the data should be output and end time of simulation
   character*200,save:: outdir,indir
@@ -77,13 +77,13 @@ use HDF5
   integer,save::flag_bnd(6)
 
 
-!for mpi 
-  integer,save::flag_mpi,flag_mpi_split,neighbor(6),my_rank,total_prc 
+!for mpi
+  integer,save::flag_mpi,flag_mpi_split,neighbor(6),my_rank,total_prc
   integer,save::mpi_siz(3),mpi_pos(3),vmpi
-  character*4 cno  
+  character*4 cno
 ! for parallel HDF5 writing & reading
   integer(HID_T), save :: file_id, plist_id
-  integer(HID_T), save :: filespace_id(4), memspace_id(4)
+  integer(HID_T), save :: filespace_id(5), memspace_id(5)
   integer(HID_T), save :: start_stop(3,2)
   integer, save :: hdf5_error
   integer(HSIZE_T), save :: dimsFile(3), dimsMem(3), hdf5_offset(3)
@@ -94,7 +94,7 @@ use HDF5
 
 !For damping across time MAKE ALLOCATABLE??, CHOOSE SENSIBLE VALUE?
   double precision,save :: oldke_damp=1.0d0
-  
+
 !Emergency save procedure
 integer,save :: esav
 double precision,save :: emsavtime

--- a/Globalvar.f90
+++ b/Globalvar.f90
@@ -6,7 +6,7 @@ module globalvar
 ! Second version - 2013/06/02
 ! Third version - 2013/06/04 NN
 !====================================================================
-
+use HDF5
 !Define global constant------------------------------------------------------
 
 !Coordinate system (only cartesian coordinates used)
@@ -81,6 +81,12 @@ module globalvar
   integer,save::flag_mpi,flag_mpi_split,neighbor(6),my_rank,total_prc 
   integer,save::mpi_siz(3),mpi_pos(3),vmpi
   character*4 cno  
+! for parallel HDF5 writing & reading
+  integer(HID_T), save :: file_id, plist_id
+  integer(HID_T), save :: filespace_id(4), memspace_id(4)
+  integer(HID_T), save :: start_stop(3,2)
+  integer, save :: hdf5_error
+  integer(HSIZE_T), save :: dimsFile(3), dimsMem(3), hdf5_offset(3)
 
 !for limit
   double precision,save :: ro_lim,pr_lim

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -35,68 +35,74 @@ module io_rot
   ! version number (date)
   integer, parameter :: mf_info=9, version=20140708,restart_unit=77
   double precision start_time,end_time
+
 contains
-!output subroutine called from main
-!  subroutine output(nout,time)
+  !output subroutine called from main
   subroutine output(out)
     integer,intent(in)::out
     integer i,j,k,outesav
-!    integer j
     double precision total_divB,cx,cy,max_C,divb
-!    double precision,intent(in)::time
-    !if nout = 0 initial setting for output is done^^^^^^^^^^^^^^^^^^^^^^
+
+    ! if nout = 0 initial setting for output is done
     nt=nt+1
     if(nout.eq.0) then
        call set_initial_out
-       call save_coordinates
-       call def_varfiles(0)
        start_time=MPI_Wtime()
        if(flag_mpi.eq.0 .or. my_rank.eq.0) then
           call mk_config
        endif
        call initialize_IOT(dtout,tend,output_type)
     endif
-    !^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-!Check for physical-time save
-end_time=MPI_Wtime()
-outesav=-1
-if (((end_time-start_time) .ge. emsavtime) .and. (esav .eq. 1)) then
-	outesav=1
-	esav=2
-     if(flag_mpi.eq.0 .or.my_rank.eq.0) &
-          write(6,*) 'calling emergency save'
-endif
-    !output variables
-  if((time.ge.get_next_output(nout,time,esav)) .or. (out.eq.1) .or. (outesav.eq.1)) then
-     !     if(flag_mpi.eq.0 .or.my_rank.eq.0) write(6,*) 'Time,dt,nout,nt,total_iter: ',time,dt,nout,nt,total_iter
-    end_time=MPI_Wtime()
-     if(flag_mpi.eq.0 .or.my_rank.eq.0) &
-!          write(6,*) 'Time,dt,dt_cnd,nout,nt,total_iter: ',time,dt,dt_cnd,nout,nt,total_iter
-          write(6,*) 'Time,dt,nout,nt,elapsed time: ',time,dt,nout,nt,end_time-start_time
-       total_divb=0.0d0
-       max_C=0.0d0
-       if(ndim.eq.100) then
-          do j=margin(2)+1,jx-margin(2);do i=margin(1)+1,ix-margin(1)
-             divb=abs((-U_m(i+2,j,1,6)+8.0d0*U_m(i+1,j,1,6)&
-                  -8.0d0*U_m(i-1,j,1,6)+U_m(i-2,j,1,6))/dx(i) +&
-                  (-U_m(i,j+2,1,7)+8.0d0*U_m(i,j+1,1,7)&
-                  -8.0d0*U_m(i,j-1,1,7)+U_m(i,j-2,1,7))/dy(j))
 
-             total_divb=total_divb +divb
-!             if(divb.gt.1.0d-13) then
-!                print *,x(i),y(j),divb
-!             endif
-             max_C=max(max_C,((-U_m(i+2,j,1,7)+8.0d0*U_m(i+1,j,1,7) &
-                  -8.0d0*U_m(i-1,j,1,7)+U_m(i-2,j,1,7))/(12.0d0*dx(i)))**2+ &
-                  ((-U_m(i,j+2,1,6)+8.0d0*U_m(i,j+1,1,6) &
-                  -8.0d0*U_m(i,j-1,1,6)+U_m(i,j-2,1,6))/(12.0d0*dy(j)))**2)
-          enddo;enddo
-          print *,"NT,TOTAL_DIVB, maxJ =",nt,total_divb,sqrt(max_C)
-       endif
-       call save_varfiles(nout)
-       nout=nout+1
+    !Check for physical-time save
+    end_time=MPI_Wtime()
+    outesav=-1
+    if (((end_time-start_time) .ge. emsavtime) .and. (esav .eq. 1)) then
+      outesav=1
+      esav=2
+      if(flag_mpi.eq.0 .or.my_rank.eq.0) &
+        write(6,*) 'calling emergency save'
     endif
 
+    ! output variables
+    if((time.ge.get_next_output(nout,time,esav)) .or. (out.eq.1) .or. (outesav.eq.1)) then
+      end_time=MPI_Wtime()
+
+      if(flag_mpi.eq.0 .or.my_rank.eq.0) &
+        write(6,*) 'Time,dt,nout,nt,elapsed time: ',time,dt,nout,nt,end_time-start_time
+
+      total_divb=0.0d0
+      max_C=0.0d0
+      if(ndim.eq.100) then
+        do j=margin(2)+1,jx-margin(2);do i=margin(1)+1,ix-margin(1)
+          divb=abs((-U_m(i+2,j,1,6)+8.0d0*U_m(i+1,j,1,6)&
+                -8.0d0*U_m(i-1,j,1,6)+U_m(i-2,j,1,6))/dx(i) +&
+                (-U_m(i,j+2,1,7)+8.0d0*U_m(i,j+1,1,7)&
+                -8.0d0*U_m(i,j-1,1,7)+U_m(i,j-2,1,7))/dy(j))
+
+          total_divb=total_divb +divb
+          max_C=max(max_C,((-U_m(i+2,j,1,7)+8.0d0*U_m(i+1,j,1,7) &
+                -8.0d0*U_m(i-1,j,1,7)+U_m(i-2,j,1,7))/(12.0d0*dx(i)))**2+ &
+                ((-U_m(i,j+2,1,6)+8.0d0*U_m(i,j+1,1,6) &
+                -8.0d0*U_m(i,j-1,1,6)+U_m(i,j-2,1,6))/(12.0d0*dy(j)))**2)
+        enddo;enddo
+        print *,"NT,TOTAL_DIVB, maxJ =",nt,total_divb,sqrt(max_C)
+      endif
+
+      ! create output parallel HDF5 file for all data in time-step
+      call create_hdf5_outfile
+      ! create file & local-memory dataspaces
+      call create_write_dataspaces
+      ! save spatial grid coordinates
+      call save_coordinates
+      ! save initial variables to output HDF5 file
+      if(nout .eq. 0) call def_varfiles(0)
+      ! Save simulation variables to output HDF5 file
+      call save_varfiles(nout)
+      call close_write_outfile
+
+      nout=nout+1
+    endif
   end subroutine output
 
   subroutine create_hdf5_outfile

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -422,12 +422,12 @@ contains
 111 continue
     read(restart_unit,*)flag_mhd,flag_pip
     read(restart_unit,*)nvar_h,nvar_m
-    read(restart_unit,*)ix,jx,kx
+    read(restart_unit,*)
     read(restart_unit,*)margin
     read(restart_unit,*)gm
     read(restart_unit,*,end=777)flag_bnd
     if(flag_mpi.eq.1) then
-      read(restart_unit,*,end=777)mpi_siz
+      read(restart_unit,*,end=777)
     endif
     if(flag_restart.eq.0) then
       key="nout"

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -576,13 +576,8 @@ contains
   subroutine read_3D_array(varname, data_out)
     integer(HID_T) :: dset_id, dataspace_id     ! dataset and file-dataspace IDs
     integer(HSSIZE_T) :: offsetFile(3)
-    integer :: per
     character(*) :: varname
     double precision, dimension(3) :: data_out(ix,jx,kx)
-
-    ! strip off '.dac.' suffix on certain variable names
-    per = index(varname, '.')
-    if(per /= 0) varname = varname(1:per-1)
 
     CALL h5dopen_f(file_id, varname, dset_id, hdf5_error)
     ! Get file dataspace

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -404,22 +404,6 @@ endif
     CALL h5dclose_f(dset_id, hdf5_error)
   end subroutine write_3D_array
 
-  subroutine save1param(q,name,nvar)
-    integer,intent(in)::nvar
-    double precision, intent(in) :: q(ix,jx,kx,nvar)
-    character(*), intent(in) :: name
-    integer, parameter :: mf_q = 999
-    integer nn
-
-    call dacdef3s(mf_q,trim(outdir) // '/' // name // cno,6,0)
-    do nn=1,nvar
-       write(mf_q) q(:,:,:,nn)
-    enddo
-!print*,mf_q,name,q(1,1,1,:)
-    close(mf_q)
-  end subroutine save1param
-
-
   subroutine set_initial_out
     integer i
     if(flag_mhd.eq.1) then
@@ -748,37 +732,6 @@ endif
     CALL h5dclose_f(dset_id, hdf5_error)
   end subroutine read_3D_array
 
-!  subroutine dacget(idf,file,nvar,restart,var)
-  subroutine dacget(idf,file,nvar,var,read_num)
-    integer,intent(in)::idf
-    integer,intent(in)::nvar
-    character*(*),intent(in)::file
-    double precision,intent(out)::var(nvar)
-    integer,optional::read_num
-    integer tmp,i
-    integer n_read,read_size
-    if(present(read_num)) then
-       n_read=read_num
-    else
-       n_read=1
-    endif
-    read_size=nvar/n_read
-
-    open(idf,file=file,form="unformatted",status="old")
-    !remove .dac. header----------------------------
-    do i=1,5
-       read(idf)tmp
-    enddo
-    i=tmp
-    !-----------------------------------------------
-!    if(present(restart)) then
-    do i=1,n_read
-       read(idf)var(1+(i-1)*read_size:read_size*i)
-    enddo
-    close(idf)
-
-  end subroutine dacget
-
   subroutine copy_time(idf,in_file,out_file,start_step)
     integer,intent(in)::idf,start_step
     integer i,tmp
@@ -825,18 +778,6 @@ endif
     close(idf)
   end subroutine get_time
 
-
-  subroutine dacdef1d(idf,file,mtype,in)
-    integer,intent(in)::idf,mtype,in
-    character*(*) file
-    open(idf,file=file,form='unformatted')
-    write(idf)1
-    write(idf)0
-    write(idf)mtype
-    write(idf)1
-    write(idf)in
-  end subroutine dacdef1d
-
   subroutine dacdef0s(idf,file,mtype,append)
     integer,intent(in)::idf,mtype,append
     character*(*) file
@@ -851,23 +792,6 @@ endif
        open(idf,file=file,form='unformatted',position='append')
     endif
   end subroutine dacdef0s
-
-  subroutine dacdef3s(idf,file,mtype,append)
-    integer,intent(in)::idf,mtype,append
-    character*(*) file
-    if(append.ne.1) then
-       open(idf,file=file,form='unformatted')
-       write(idf)1
-       write(idf)0
-       write(idf)mtype
-       write(idf)4
-       write(idf)ix,jx,kx,-1
-    else
-
-       open(idf,file=file,form='unformatted',position='append')
-    endif
-  end subroutine dacdef3s
-
 
 
   subroutine stop_sim

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -6,6 +6,7 @@ module io_rot
 ! First version - 2013/04/26 NN
 ! Modification history
 ! 2013/05/29  S.Takasao
+! 2022/03/18  M.T.West
 !====================================================================
   use globalvar,only:ix,jx,kx,ndim,dt,dt_cnd,U_h,U_m,time,cno,flag_stop,&
        flag_mhd,flag_pip,flag_mpi,my_rank,indir,outdir,&
@@ -31,7 +32,8 @@ module io_rot
                        ,mf_x=11, mf_y=12, mf_z=13 &
                        ,mf_dx=14, mf_dy=15, mf_dz=16
   ! version number (date)
-  integer, parameter :: mf_info=9, version=20140708,restart_unit=77
+  integer, parameter :: mf_info=10, version=20220318
+  integer, parameter :: restart_unit=77
   double precision start_time,end_time
 
 contains

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -305,26 +305,27 @@ endif
 
 !   end subroutine def_varfiles
 
- !close file units
+  !close file units
   subroutine epilogue
     integer i
     if(flag_mpi.eq.0 .or.my_rank.eq.0) then
-       print *,"END of simulation total loop ",nt
-       open(99,file=trim(outdir) // "/config.txt",status="old",form="formatted",position="append")
-!       open(99,file=trim(outdir) // "/config.txt",status="replace",form="formatted")
-       write(99,*)"nout:",nout
-       close(99)
-
+      print *,"END of simulation total loop ",nt
+      open(99,file=trim(outdir) // "/config.txt",status="old",form="formatted",position="append")
+      write(99,*)"nout:",nout
+      close(99)
     endif
     end_time=MPI_Wtime()
     if(my_rank.eq.0) then
-       write(*,*)"CPU TIME FOR CALCULATION IS :",end_time-start_time
+      write(*,*)"CPU TIME FOR CALCULATION IS :",end_time-start_time
     endif
-!    call mk_result
+
+    ! Close MPI interface
     if(flag_mpi.eq.1) then
-       call end_mpi
+      call end_mpi
     endif
     close(mf_t)
+    ! Close FORTRAN interface.
+    call h5close_f(hdf5_error)
   end subroutine epilogue
 
 !  subroutine save_varfiles(t)

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -600,7 +600,6 @@ contains
 
   subroutine read_3D_array(varname, data_out)
     integer(HID_T) :: dset_id, dataspace_id     ! dataset and file-dataspace IDs
-    integer(HSIZE_T) :: dimsFile(3), dimsMem(3)
     integer(HSSIZE_T) :: offsetFile(3)
     integer :: per
     character(*) :: varname

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -280,7 +280,7 @@ contains
     if(flag_mpi.eq.1) then
       call end_mpi
       ! Close FORTRAN interface
-      if(my_rank.eq.0) call h5close_f(hdf5_error)
+      !if(my_rank.eq.0) call h5close_f(hdf5_error)
     endif
     close(mf_t)
   end subroutine epilogue

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -258,13 +258,12 @@ contains
       write(*,*)"CPU TIME FOR CALCULATION IS :",end_time-start_time
     endif
 
-    ! Close MPI interface
     if(flag_mpi.eq.1) then
       call end_mpi
+      ! Close FORTRAN interface
+      if(my_rank.eq.0) call h5close_f(hdf5_error)
     endif
     close(mf_t)
-    ! Close FORTRAN interface.
-    call h5close_f(hdf5_error)
   end subroutine epilogue
 
   subroutine save_varfiles(n_out)

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -15,10 +15,13 @@ module io_rot
        total_iter,flag_amb,dtout,mpi_siz,nt,nmax,output_type,flag_ps,flag_divb,&
        flag_damp,damp_time,flag_rad,flag_ir_type,arb_heat,visc,esav,emsavtime,&
        ac_sav, xi_sav, ion_sav, rec_sav, col_sav, gr_sav, vs_sav, heat_sav, et_sav, ps_sav,&
-       Nexcite
+       Nexcite, &
+       file_id, plist_id, hdf5_error, filespace_id, memspace_id,&
+       dimsFile, dimsMem, start_stop, hdf5_offset, neighbor, ig
   use mpi_rot,only:end_mpi
   use IOT_rot,only:initialize_IOT,get_next_output
   use Util_rot,only:get_word,get_value_integer
+  use HDF5
   implicit none
   include "mpif.h"
   integer ios

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -175,42 +175,14 @@ contains
   end subroutine close_write_outfile
 
   subroutine save_coordinates
-    character*4 tmp_id
-
-    if(flag_mpi.eq.0 .or.(mpi_pos(2).eq.0.and.mpi_pos(3).eq.0)) then
-       write(tmp_id,"(i4.4)")mpi_pos(1)
-       call dacdef1d(mf_x,trim(outdir) // 'x.dac.'//tmp_id,6,ix)
-       write(mf_x) x
-       call dacdef1d(mf_dx,trim(outdir) // 'dx.dac.'//tmp_id,6,ix)
-       write(mf_dx) dx
-       close(mf_x)
-       close(mf_dx)
-    endif
-
-    if(ndim.ge.2) then
-       if(flag_mpi.eq.0 .or.(mpi_pos(1).eq.0.and.mpi_pos(3).eq.0)) then
-          write(tmp_id,"(i4.4)")mpi_pos(2)
-          call dacdef1d(mf_y,trim(outdir) // 'y.dac.'//tmp_id,6,jx)
-          write(mf_y) y
-          call dacdef1d(mf_dy,trim(outdir) // 'dy.dac.'//tmp_id,6,jx)
-          write(mf_dy) dy
-          close(mf_y)
-          close(mf_dy)
-
-       endif
-       if(ndim.ge.3) then
-          if(flag_mpi.eq.0 .or.(mpi_pos(1).eq.0.and.mpi_pos(2).eq.0)) then
-             write(tmp_id,"(i4.4)")mpi_pos(3)
-             call dacdef1d(mf_z,trim(outdir) // 'z.dac.'//tmp_id,6,kx)
-             write(mf_z) z
-             call dacdef1d(mf_dz,trim(outdir) // 'dz.dac.'//tmp_id,6,kx)
-             write(mf_dz) dz
-             close(mf_z)
-             close(mf_dz)
-          endif
-       endif
-    endif
-
+    ! Save the coordinate grids into the parallel HDF5 file
+    call write_1D_array(1, "xgrid", x)
+    call write_1D_array(2, "ygrid", y)
+    call write_1D_array(3, "zgrid", z)
+    ! Also include the grid spacings
+    call write_1D_array(1, "dx", dx)
+    call write_1D_array(2, "dy", dy)
+    call write_1D_array(3, "dz", dz)
   end subroutine save_coordinates
 
   subroutine write_1D_array(n, varname, data_array)
@@ -599,21 +571,14 @@ contains
   end subroutine reconf_grid_space
 
   subroutine reread_coordinate
-    character*4 tmp_id
-    write(tmp_id,"(i4.4)")mpi_pos(1)
-
-    call dacget(51,trim(indir) // 'x.dac.'//tmp_id,ix,x)
-    call dacget(51,trim(indir) // 'dx.dac.'//tmp_id,ix,dx)
-    if(ndim.ge.2)then
-       write(tmp_id,"(i4.4)")mpi_pos(2)
-       call dacget(51,trim(indir) // 'y.dac.'//tmp_id,jx,y)
-       call dacget(51,trim(indir) // 'dy.dac.'//tmp_id,jx,dy)
-       if(ndim.ge.3)then
-          write(tmp_id,"(i4.4)")mpi_pos(3)
-          call dacget(51,trim(indir) // 'z.dac.'//tmp_id,kx,z)
-          call dacget(51,trim(indir) // 'dz.dac.'//tmp_id,kx,dz)
-       endif
-    endif
+    ! Save the coordinate grids into the parallel HDF5 file
+    call read_1D_array(1, "xgrid", x)
+    call read_1D_array(2, "ygrid", y)
+    call read_1D_array(3, "zgrid", z)
+    ! Also include the grid spacings
+    call read_1D_array(1, "dx", dx)
+    call read_1D_array(2, "dy", dy)
+    call read_1D_array(3, "dz", dz)
   end subroutine reread_coordinate
 
   subroutine read_1D_array(n, varname, data_out)

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -25,8 +25,6 @@ module io_rot
   implicit none
   include "mpif.h"
   integer ios
-  integer,allocatable,save::mf_m(:,:),mf_h(:,:)
-!  integer,save::mf_m(8,2),mf_h(5,2)
   character*15,allocatable::file_m(:),file_h(:)
   character*4 tno
   integer, parameter :: mf_t=10 &
@@ -355,48 +353,16 @@ contains
   subroutine set_initial_out
     integer i
     if(flag_mhd.eq.1) then
-          allocate(mf_m(nvar_m,2),file_m(nvar_m))
-          do i=1,nvar_m
-             mf_m(i,1)=19+i
-             mf_m(i,2)=i
-          enddo
-          file_m(1)='ro_p.dac.'
-          file_m(2)='mx_p.dac.'
-          file_m(3)='my_p.dac.'
-          file_m(4)='mz_p.dac.'
-          file_m(5)='en_p.dac.'
-          file_m(6)='bx.dac.'
-          file_m(7)='by.dac.'
-          file_m(8)='bz.dac.'
-          if(flag_divb.eq.1.or.flag_divb.eq.2) &
-               file_m(9)='ps.dac.'
-       endif
-       if(flag_pip.eq.1.or.flag_mhd.eq.0) then
-          allocate(mf_h(nvar_h,2),file_h(nvar_h))
-!          allocate(file_h(nvar_h))
-          do i=1,nvar_h
-             mf_h(i,1)=30+i
-             mf_h(i,2)=i
-          enddo
-
-          file_h(1)='ro_n.dac.'
-          file_h(2)='mx_n.dac.'
-          file_h(3)='my_n.dac.'
-          file_h(4)='mz_n.dac.'
-          file_h(5)='en_n.dac.'
-       endif
-  end subroutine set_initial_out
-  subroutine reset_out
-    if(flag_mhd.eq.1) then
-       deallocate(file_m,mf_m)
+      allocate(file_m(nvar_m))
+      file_m(1:5)= ['ro_p', 'mx_p', 'my_p', 'mz_p', 'en_p']
+      file_m(6:8) = ['bx', 'by', 'bz']
+      if(flag_divb.eq.1.or.flag_divb.eq.2) file_m(9)='ps.dac.'
     endif
     if(flag_pip.eq.1.or.flag_mhd.eq.0) then
-       deallocate(file_h,mf_h)
+      allocate(file_h(nvar_h))
+      file_h(1:5)=['ro_n', 'mx_n', 'my_n', 'mz_n', 'en_n']
     endif
-  end subroutine reset_out
-
-
-
+  end subroutine set_initial_out
 
   !Modification for restart setting NN 2015/08/27
   subroutine mk_config
@@ -580,12 +546,12 @@ contains
 
     if(flag_mhd.eq.1) then
       do i=1,nvar_m
-        call read_3D_array(trim(file_m(i)), U_m(:,:,:,mf_m(i,2)))
+        call read_3D_array(trim(file_m(i)), U_m(:,:,:,i))
       enddo
     endif
     if(flag_pip.eq.1.or.flag_mhd.eq.0) then
       do i=1,nvar_h
-        call read_3D_array(trim(file_h(i)), U_h(:,:,:,mf_h(i,2)))
+        call read_3D_array(trim(file_h(i)), U_h(:,:,:,i))
       enddo
     endif
 

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -213,75 +213,36 @@ contains
 
   subroutine def_varfiles(append)
     integer,intent(in)::append
-    integer i
-
-    write(tno,"(i4.4)")nout
-
 
     if(flag_pip.eq.1.or.flag_amb.eq.1) then
-!print*,'ac_sav',ac_sav
-!print*,'xi_sav',xi_sav
-       if(ac_sav.eq.0) call save1param(ac,tno//'ac.dac.',1)
-       if(xi_sav.eq.0) call save1param(xi_n,tno//'xi.dac.',1)
+      if(ac_sav.eq.0) call write_3D_array("ac", ac)
+      if(xi_sav.eq.0) call write_3D_array("xi", xi_n)
     endif
     if(flag_pip.eq.1.and.flag_ir.eq.1) then
-       if(ion_sav.eq.0) call save1param(Gm_ion,tno//'ion.dac.',1)
-       if(rec_sav.eq.0) call save1param(Gm_rec,tno//'rec.dac.',1)
+      if(ion_sav.eq.0) call write_3D_array("ion", Gm_ion)
+      if(rec_sav.eq.0) call write_3D_array("rec", Gm_rec)
     endif
     if(flag_mhd.eq.1.and.flag_resi.eq.1) then
-       if(et_sav.eq.0) call save1param(eta,tno//'et.dac.',1)
+      if(et_sav.eq.0) call write_3D_array("et", eta)
     endif
     if(flag_col.eq.1) then
-       if(col_sav.eq.0) call save1param(ac,tno//'col.dac.',1)
+      if(col_sav.eq.0) call write_3D_array("col", ac)
     endif
 
     if(flag_grav.eq.1) then
-       if(gr_sav.eq.0) call save1param(gra,tno//'gr.dac.',3)
+      if(gr_sav.eq.0) call write_3D_array("gr", gra)
     endif
     if(flag_visc.eq.1) then
-       if(vs_sav.eq.0) call save1param(mu,tno//'vs.dac.',1)
+      if(vs_sav.eq.0) call write_3D_array("vs", mu)
     endif
     if(flag_pip.eq.1.and.flag_ir_type.eq.0.and.flag_IR.ne.0) then
-       if(heat_sav.eq.0) call save1param(arb_heat,tno//'aheat.dac.',1)
+      if(heat_sav.eq.0) call write_3D_array("aheat", arb_heat)
     endif
 
-
-    if(flag_mpi.eq.0 .or.my_rank.eq.0)      &
-         call dacdef0s(mf_t,trim(outdir) // 't.dac.'//cno,6,append)
-
+    if(flag_mpi.eq.0 .or.my_rank.eq.0) then
+      call dacdef0s(mf_t,trim(outdir) // 't.dac.'//cno,6,append)
+    end if
   end subroutine def_varfiles
-
-
-!   subroutine def_varfiles(append)
-!     integer,intent(in)::append
-!     integer i
-
-!     if(flag_mpi.eq.0 .or.my_rank.eq.0)      &
-!          call dacdef0s(mf_t,trim(outdir) // '/t.dac.'//cno,6,append)
-!     if(flag_mhd.eq.1) then
-! !       do i=1,nvar_m
-! !       print *,"OK",my_rank,file_m(1)//cno
-!        do i=1,8
-!           call dacdef3s(mf_m(i,1),trim(outdir)//trim(file_m(i))//cno,6,append)
-!        enddo
-!        if(flag_resi.ge.2) then
-!           call dacdef3s(77,trim(outdir)//'/et.dac.'//cno,6,append)
-!        endif
-!        if(flag_ir.ge.2) then
-!           call dacdef3s(78,trim(outdir)//'/ion.dac.'//cno,6,append)
-!           call dacdef3s(79,trim(outdir)//'/rec.dac.'//cno,6,append)
-! !          call dacdef3s(Gm_ion,'ion.dac.',1)
-! !          call dacdef3s(Gm_rec,'rec.dac.',1)
-!        endif
-
-!     endif
-!     if(flag_pip.eq.1.or.flag_mhd.eq.0) then
-!        do i=1,nvar_h
-!           call dacdef3s(mf_h(i,1),trim(outdir) // trim(file_h(i))//cno,6,append)
-!        enddo
-!     endif
-
-!   end subroutine def_varfiles
 
   !close file units
   subroutine epilogue

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -556,53 +556,39 @@ contains
   end subroutine read_1D_array
 
   subroutine reread_variables
-    integer nvar,i
-    character*4 step_char
-    write(step_char,"(i4.4)")flag_restart
-    nvar=ix
-    if(ndim.ge.2)nvar=nvar*jx
-    if(ndim.ge.3)nvar=nvar*kx
+    integer i
 
     call set_initial_out
-    if(flag_mhd.eq.1) then
-       do i=1,nvar_m
-          call dacget(mf_m(i,1),trim(indir)//step_char//trim(file_m(i))//cno,nvar, &
-               U_m(:,:,:,mf_m(i,2)))
-       enddo
-    endif
 
-    if(flag_pip.eq.1.or.flag_mhd.eq.0) then
-       do i=1,nvar_h
-          call dacget(mf_h(i,1),trim(indir)//step_char//trim(file_h(i))//cno,nvar,&
-               U_h(:,:,:,mf_h(i,2)))
-       enddo
+    if(flag_mhd.eq.1) then
+      do i=1,nvar_m
+        call read_3D_array(trim(file_m(i)), U_m(:,:,:,mf_m(i,2)))
+      enddo
     endif
-!    call reset_out
+    if(flag_pip.eq.1.or.flag_mhd.eq.0) then
+      do i=1,nvar_h
+        call read_3D_array(trim(file_h(i)), U_h(:,:,:,mf_h(i,2)))
+      enddo
+    endif
 
     if(flag_resi.ge.1) then
-       call dacget(11,trim(indir)//step_char//'et.dac.'//cno,nvar,eta(:,:,:))
+      call read_3D_array('et', eta(:,:,:))
     endif
-
 
     if(flag_pip.eq.1.and.flag_col.ge.1) then
-       call dacget(11,trim(indir)//step_char//'ac.dac.'//cno,nvar,ac(:,:,:))
+      call read_3D_array('ac', ac(:,:,:))
     endif
-
     if(flag_pip.eq.1.and.flag_ir.ge.1) then
-       call dacget(11,trim(indir)//step_char//'ion.dac.'//cno,nvar,gm_ion(:,:,:))
-       call dacget(11,trim(indir)//step_char//'rec.dac.'//cno,nvar,gm_rec(:,:,:))
-	if (flag_ir_type .eq.0) then
-		allocate(arb_heat(ix,jx,kx))
-		call dacget(11,trim(indir)//step_char//'aheat.dac.'//cno,nvar,arb_heat(:,:,:))
-	endif
-!       print *,"GM_ION",maxval(gm_ion),minval(gm_ion)
-!       print *,"GM_REC",maxval(gm_rec),minval(gm_rec)
+      call read_3D_array('ion', gm_ion(:,:,:))
+      call read_3D_array('rec', gm_rec(:,:,:))
+      if (flag_ir_type .eq.0) then
+        allocate(arb_heat(ix,jx,kx))
+        call read_3D_array('aheat', arb_heat(:,:,:))
+  	  endif
     endif
 
     if(flag_grav.ge.1) then
-!      do i=1,3
-          call dacget(11,trim(indir)//step_char//'gr.dac.'//cno,nvar*3,gra,3)
-!       enddo
+      call read_3D_array('gr', gra)
     endif
 
     !! read time (by Tak)
@@ -611,7 +597,6 @@ contains
     if(my_rank.eq.0) then
        call copy_time(mf_t,trim(indir)//'t.dac.0000',trim(outdir)//'t.dac.0000',flag_restart+1)
     endif
-
   end subroutine reread_variables
 
   subroutine read_3D_array(varname, data_out)

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -28,7 +28,6 @@ module io_rot
   integer ios
   character*15,allocatable::file_m(:),file_h(:)
   character*4 tno
-  integer, parameter :: mf_t=10
   ! version number (date)
   integer, parameter :: mf_info=10, version=20220318
   integer, parameter :: restart_unit=77
@@ -256,9 +255,6 @@ contains
       if(heat_sav.eq.0) call write_3D_array("aheat", arb_heat)
     endif
 
-    !if(flag_mpi.eq.0 .or.my_rank.eq.0) then
-    !  call dacdef0s(mf_t,trim(outdir) // 't.dac.'//cno,6,append)
-    !end if
   end subroutine def_varfiles
 
   !close file units
@@ -280,7 +276,6 @@ contains
       ! Close FORTRAN interface
       !if(my_rank.eq.0) call h5close_f(hdf5_error)
     endif
-    close(mf_t)
   end subroutine epilogue
 
   subroutine save_varfiles(n_out)
@@ -288,8 +283,6 @@ contains
     character(8) :: Nexc_name
 
     if(n_out.ne.0) call def_varfiles(1)
-    write(mf_t) time
-    close(mf_t)
 
     if(flag_mhd.eq.1) then
       do i=1,nvar_m
@@ -617,68 +610,6 @@ contains
     CALL h5sclose_f(dataspace_id, hdf5_error)
     CALL h5dclose_f(dset_id, hdf5_error)
   end subroutine read_time
-
-  subroutine copy_time(idf,in_file,out_file,start_step)
-    integer,intent(in)::idf,start_step
-    integer i,tmp
-    character*(*),intent(in)::in_file
-    character*(*),intent(in)::out_file
-    double precision time_tmp
-    double precision times(start_step)
-    open(idf,file=in_file,form="unformatted",status="old")
-    !remove .dac. header----------------------------
-    do i=1,5
-       read(idf)tmp
-    enddo
-    !-----------------------------------------------
-    do i=1,start_step
-       read(idf)time_tmp
-       times(i)=time_tmp
-    enddo
-    close(idf)
-
-    call dacdef0s(idf,out_file,6,0)
-    do i=1,start_step
-       write(idf)times(i)
-    end do
-    close(idf)
-
-  end subroutine copy_time
-
-  !! Get time when the calculation is restarted (by Tak)
-  subroutine get_time(idf,file,restart,time_tmp)
-    integer,intent(in)::idf
-    integer,intent(in)::restart
-    character*(*),intent(in)::file
-    double precision,intent(out)::time_tmp
-    integer tmp,i
-    open(idf,file=file,form="unformatted",status="old")
-    !remove .dac. header----------------------------
-    do i=1,5
-       read(idf)tmp
-    enddo
-    !-----------------------------------------------
-    do i=1,restart+1
-       read(idf)time_tmp
-    enddo
-    close(idf)
-  end subroutine get_time
-
-  subroutine dacdef0s(idf,file,mtype,append)
-    integer,intent(in)::idf,mtype,append
-    character*(*) file
-    if(append.ne.1) then
-       open(idf,file=file,form='unformatted')
-       write(idf)1
-       write(idf)0
-       write(idf)mtype
-       write(idf)1
-       write(idf)-1
-    else
-       open(idf,file=file,form='unformatted',position='append')
-    endif
-  end subroutine dacdef0s
-
 
   subroutine stop_sim
     !----------------------------------------------------------------------|

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -267,54 +267,44 @@ contains
     call h5close_f(hdf5_error)
   end subroutine epilogue
 
-!  subroutine save_varfiles(t)
   subroutine save_varfiles(n_out)
-    integer n_out
-    integer i
-!    double precision, intent(in) :: t
+    integer n_out, i
+    character(8) :: Nexc_name
 
-
-    if(n_out.ne.0) then
-       call def_varfiles(1)
-    endif
+    if(n_out.ne.0) call def_varfiles(1)
     write(mf_t) time
     close(mf_t)
+
     if(flag_mhd.eq.1) then
-       do i=1,nvar_m
-          call save1param(U_m(:,:,:,i),tno//trim(file_m(i)),1)
-       enddo
-       if(flag_resi.ge.2) then
-          if(et_sav.eq.0) call save1param(eta,tno//"et.dac.",1)
-       endif
-       if(flag_ir.ge.1) then
-!	print*,gm_ion
-          if(ion_sav.eq.0) call save1param(Gm_ion,tno//'ion.dac.',1)
-          if(rec_sav.eq.0) call save1param(Gm_rec,tno//'rec.dac.',1)
-       endif
-      if(flag_ir.eq.4) then
-        !print*,Nexcite(1,1,1,:)
-        call save1param(Nexcite(:,:,:,1),tno//'nexcite1.dac.',1)
-        call save1param(Nexcite(:,:,:,2),tno//'nexcite2.dac.',1)
-        call save1param(Nexcite(:,:,:,3),tno//'nexcite3.dac.',1)
-        call save1param(Nexcite(:,:,:,4),tno//'nexcite4.dac.',1)
-        call save1param(Nexcite(:,:,:,5),tno//'nexcite5.dac.',1)
-        call save1param(Nexcite(:,:,:,6),tno//'nexcite6.dac.',1)
+      do i=1,nvar_m
+        if((i.lt.9) .or. (flag_divb.eq.1 .and. ps_sav .eq.0)) then
+          call write_3D_array(trim(file_m(i)), U_m(:,:,:,i))
+        end if
+      enddo
+      if(flag_resi.ge.2) then
+        if(et_sav.eq.0) call write_3D_array("et", eta)
       endif
-       if((flag_visc.ge.1).and.(vs_sav.eq.0)) then
-          call save1param(visc(:,:,:,1),tno//"viscx.dac.",1)
-          call save1param(visc(:,:,:,2),tno//"viscy.dac.",1)
-          call save1param(visc(:,:,:,3),tno//"viscz.dac.",1)
-       endif
+      if(flag_ir.ge.1) then
+        if(ion_sav.eq.0) call write_3D_array("ion", Gm_ion)
+        if(rec_sav.eq.0) call write_3D_array("rec", Gm_rec)
+      endif
+      if(flag_ir.eq.4) then
+        do i=1,6
+          write(Nexc_name, '(a, i0)') 'nexcite', i
+          call write_3D_array(Nexc_name, Nexcite(:,:,:,i))
+        end do
+      endif
+      if((flag_visc.ge.1).and.(vs_sav.eq.0)) then
+        call write_3D_array("viscx", visc(:,:,:,1))
+        call write_3D_array("viscy", visc(:,:,:,2))
+        call write_3D_array("viscz", visc(:,:,:,3))
+      endif
     endif
     if(flag_pip.eq.1 .or.flag_mhd.eq.0) then
-       do i=1,nvar_h
-          call save1param(U_h(:,:,:,i),tno//trim(file_h(i)),1)
-       enddo
+      do i=1,nvar_h
+        call write_3D_array(trim(file_h(i)), U_h(:,:,:,i))
+      enddo
     endif
-    if(flag_divb.eq.1 .and. flag_mhd.eq.1 .and. ps_sav .eq.0) then
-       call save1param(U_m(:,:,:,9),tno//trim(file_m(9)),1)
-    endif
-
   end subroutine save_varfiles
 
   subroutine write_3D_array(varname, data_array)

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -28,9 +28,7 @@ module io_rot
   integer ios
   character*15,allocatable::file_m(:),file_h(:)
   character*4 tno
-  integer, parameter :: mf_t=10 &
-                       ,mf_x=11, mf_y=12, mf_z=13 &
-                       ,mf_dx=14, mf_dy=15, mf_dz=16
+  integer, parameter :: mf_t=10
   ! version number (date)
   integer, parameter :: mf_info=10, version=20220318
   integer, parameter :: restart_unit=77

--- a/IO_rot.f90
+++ b/IO_rot.f90
@@ -1,7 +1,7 @@
 module io_rot
 !====================================================================
 ! This is the in_out module for the PIP code.
-! Module for input and output 
+! Module for input and output
 ! Author A.Hillier
 ! First version - 2013/04/26 NN
 ! Modification history
@@ -48,9 +48,9 @@ contains
     nt=nt+1
     if(nout.eq.0) then
        call set_initial_out
-       call save_coordinates            
+       call save_coordinates
        call def_varfiles(0)
-       start_time=MPI_Wtime()  
+       start_time=MPI_Wtime()
        if(flag_mpi.eq.0 .or. my_rank.eq.0) then
           call mk_config
        endif
@@ -59,20 +59,20 @@ contains
     !^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 !Check for physical-time save
 end_time=MPI_Wtime()
-outesav=-1 
+outesav=-1
 if (((end_time-start_time) .ge. emsavtime) .and. (esav .eq. 1)) then
 	outesav=1
 	esav=2
      if(flag_mpi.eq.0 .or.my_rank.eq.0) &
           write(6,*) 'calling emergency save'
-endif  
-    !output variables 
+endif
+    !output variables
   if((time.ge.get_next_output(nout,time,esav)) .or. (out.eq.1) .or. (outesav.eq.1)) then
      !     if(flag_mpi.eq.0 .or.my_rank.eq.0) write(6,*) 'Time,dt,nout,nt,total_iter: ',time,dt,nout,nt,total_iter
-    end_time=MPI_Wtime() 
+    end_time=MPI_Wtime()
      if(flag_mpi.eq.0 .or.my_rank.eq.0) &
-!          write(6,*) 'Time,dt,dt_cnd,nout,nt,total_iter: ',time,dt,dt_cnd,nout,nt,total_iter 
-          write(6,*) 'Time,dt,nout,nt,elapsed time: ',time,dt,nout,nt,end_time-start_time   
+!          write(6,*) 'Time,dt,dt_cnd,nout,nt,total_iter: ',time,dt,dt_cnd,nout,nt,total_iter
+          write(6,*) 'Time,dt,nout,nt,elapsed time: ',time,dt,nout,nt,end_time-start_time
        total_divb=0.0d0
        max_C=0.0d0
        if(ndim.eq.100) then
@@ -90,8 +90,8 @@ endif
                   -8.0d0*U_m(i-1,j,1,7)+U_m(i-2,j,1,7))/(12.0d0*dx(i)))**2+ &
                   ((-U_m(i,j+2,1,6)+8.0d0*U_m(i,j+1,1,6) &
                   -8.0d0*U_m(i,j-1,1,6)+U_m(i,j-2,1,6))/(12.0d0*dy(j)))**2)
-          enddo;enddo          
-          print *,"NT,TOTAL_DIVB, maxJ =",nt,total_divb,sqrt(max_C)          
+          enddo;enddo
+          print *,"NT,TOTAL_DIVB, maxJ =",nt,total_divb,sqrt(max_C)
        endif
        call save_varfiles(nout)
        nout=nout+1
@@ -111,7 +111,7 @@ endif
        close(mf_x)
        close(mf_dx)
     endif
-    
+
     if(ndim.ge.2) then
        if(flag_mpi.eq.0 .or.(mpi_pos(1).eq.0.and.mpi_pos(3).eq.0)) then
           write(tmp_id,"(i4.4)")mpi_pos(2)
@@ -135,7 +135,7 @@ endif
           endif
        endif
     endif
-    
+
   end subroutine save_coordinates
 
   subroutine def_varfiles(append)
@@ -143,7 +143,7 @@ endif
     integer i
 
     write(tno,"(i4.4)")nout
-    
+
 
     if(flag_pip.eq.1.or.flag_amb.eq.1) then
 !print*,'ac_sav',ac_sav
@@ -161,7 +161,7 @@ endif
     if(flag_col.eq.1) then
        if(col_sav.eq.0) call save1param(ac,tno//'col.dac.',1)
     endif
-     
+
     if(flag_grav.eq.1) then
        if(gr_sav.eq.0) call save1param(gra,tno//'gr.dac.',3)
     endif
@@ -173,17 +173,17 @@ endif
     endif
 
 
-    if(flag_mpi.eq.0 .or.my_rank.eq.0)      &         
+    if(flag_mpi.eq.0 .or.my_rank.eq.0)      &
          call dacdef0s(mf_t,trim(outdir) // 't.dac.'//cno,6,append)
 
   end subroutine def_varfiles
 
-  
+
 !   subroutine def_varfiles(append)
 !     integer,intent(in)::append
 !     integer i
 
-!     if(flag_mpi.eq.0 .or.my_rank.eq.0)      &         
+!     if(flag_mpi.eq.0 .or.my_rank.eq.0)      &
 !          call dacdef0s(mf_t,trim(outdir) // '/t.dac.'//cno,6,append)
 !     if(flag_mhd.eq.1) then
 ! !       do i=1,nvar_m
@@ -229,7 +229,7 @@ endif
     if(flag_mpi.eq.1) then
        call end_mpi
     endif
-    close(mf_t)          
+    close(mf_t)
   end subroutine epilogue
 
 !  subroutine save_varfiles(t)
@@ -242,7 +242,7 @@ endif
     if(n_out.ne.0) then
        call def_varfiles(1)
     endif
-    write(mf_t) time    
+    write(mf_t) time
     close(mf_t)
     if(flag_mhd.eq.1) then
        do i=1,nvar_m
@@ -256,7 +256,7 @@ endif
           if(ion_sav.eq.0) call save1param(Gm_ion,tno//'ion.dac.',1)
           if(rec_sav.eq.0) call save1param(Gm_rec,tno//'rec.dac.',1)
        endif
-      if(flag_ir.eq.4) then 
+      if(flag_ir.eq.4) then
         !print*,Nexcite(1,1,1,:)
         call save1param(Nexcite(:,:,:,1),tno//'nexcite1.dac.',1)
         call save1param(Nexcite(:,:,:,2),tno//'nexcite2.dac.',1)
@@ -276,10 +276,10 @@ endif
           call save1param(U_h(:,:,:,i),tno//trim(file_h(i)),1)
        enddo
     endif
-    if(flag_divb.eq.1 .and. flag_mhd.eq.1 .and. ps_sav .eq.0) then    
+    if(flag_divb.eq.1 .and. flag_mhd.eq.1 .and. ps_sav .eq.0) then
        call save1param(U_m(:,:,:,9),tno//trim(file_m(9)),1)
     endif
-    
+
   end subroutine save_varfiles
 
   subroutine save1param(q,name,nvar)
@@ -288,7 +288,7 @@ endif
     character(*), intent(in) :: name
     integer, parameter :: mf_q = 999
     integer nn
-    
+
     call dacdef3s(mf_q,trim(outdir) // '/' // name // cno,6,0)
     do nn=1,nvar
        write(mf_q) q(:,:,:,nn)
@@ -296,7 +296,7 @@ endif
 !print*,mf_q,name,q(1,1,1,:)
     close(mf_q)
   end subroutine save1param
-  
+
 
   subroutine set_initial_out
     integer i
@@ -304,15 +304,15 @@ endif
           allocate(mf_m(nvar_m,2),file_m(nvar_m))
           do i=1,nvar_m
              mf_m(i,1)=19+i
-             mf_m(i,2)=i         
+             mf_m(i,2)=i
           enddo
-          file_m(1)='ro_p.dac.' 
-          file_m(2)='mx_p.dac.' 
-          file_m(3)='my_p.dac.' 
-          file_m(4)='mz_p.dac.' 
-          file_m(5)='en_p.dac.' 
-          file_m(6)='bx.dac.' 
-          file_m(7)='by.dac.' 
+          file_m(1)='ro_p.dac.'
+          file_m(2)='mx_p.dac.'
+          file_m(3)='my_p.dac.'
+          file_m(4)='mz_p.dac.'
+          file_m(5)='en_p.dac.'
+          file_m(6)='bx.dac.'
+          file_m(7)='by.dac.'
           file_m(8)='bz.dac.'
           if(flag_divb.eq.1.or.flag_divb.eq.2) &
                file_m(9)='ps.dac.'
@@ -324,7 +324,7 @@ endif
              mf_h(i,1)=30+i
              mf_h(i,2)=i
           enddo
-         
+
           file_h(1)='ro_n.dac.'
           file_h(2)='mx_n.dac.'
           file_h(3)='my_n.dac.'
@@ -351,9 +351,9 @@ endif
     integer ind_e
     open(11,file='setting.txt',form='formatted',status='old')
     open(99,file=trim(outdir) // "/config.txt",status="replace",form="formatted")
-    do 
+    do
        read(11,"(A)",end=999)tmp
-       call get_word(tmp,key,ind_e)       
+       call get_word(tmp,key,ind_e)
        if(ind_e.gt.1) write(99,"(A)")key//":"//tmp(1:ind_e-1)
     enddo
 999 continue
@@ -361,17 +361,17 @@ endif
     write(99,"(A)")"ENDSETTING"
     write(99,*)flag_mhd,flag_pip, " #mhd and pip flag"
     write(99,*)nvar_h,nvar_m, " #number of variables"
-    write(99,*)ix,jx,kx, " # used grid numbers" 
-    write(99,*)margin, " # used margin grid numbers" 
+    write(99,*)ix,jx,kx, " # used grid numbers"
+    write(99,*)margin, " # used margin grid numbers"
     write(99,*)gm," #Abiabatic constant"
     write(99,*)flag_bnd
 !    write(99,*)flag_damp,damp_time, "velocity damping"
     if(flag_mpi.eq.1) then
        write(99,*)mpi_siz," #mpi domain size"
     endif
-    close(99)    
+    close(99)
   end subroutine mk_config
-  
+
   !! restart routine should be modified
   subroutine restart
     integer tmp,out_tmp
@@ -382,7 +382,7 @@ endif
     !Modification restart setting 2015/08/27 NN======================
 
     open(restart_unit,file=trim(indir)//"config.txt",status="old",form="formatted")
-    do  
+    do
        read(restart_unit,*,end=111)line
        if(trim(line)=="ENDSETTING") exit
     enddo
@@ -401,8 +401,8 @@ endif
        read(restart_unit,*,end=777)mpi_siz
     endif
     if(flag_restart.eq.0) then
-       key="nout"       
-       do           
+       key="nout"
+       do
           read(restart_unit,"(A)",end=888)line
           call get_value_integer(line,key,out_tmp)
        enddo
@@ -410,8 +410,8 @@ endif
        flag_restart=out_tmp-1
     endif
 !    if(flag_restart.eq.-1) then
-!       key="nout"       
-!       do           
+!       key="nout"
+!       do
 !          read(restart_unit,"(A)",end=889)line
 !          call get_value_integer(line,key,out_tmp)
 !       enddo
@@ -428,20 +428,20 @@ endif
     call reread_coordinate
     if (flag_mpi.eq.0 .or. my_rank.eq.0) then
        print *,"Now reading data from [",trim(indir),"] ..."
-       print *,"start step is : ",flag_restart 
+       print *,"start step is : ",flag_restart
     endif
     call reread_variables
-    
-    
+
+
     if (flag_mpi.eq.0 .or. my_rank.eq.0) print *,"reading Finish."
 !    if (flag_mpi.eq.0 .or. my_rank.eq.1) print *,"dtout=",dtout
 
     call reconf_grid_space
 
-    nout = flag_restart+1 
+    nout = flag_restart+1
 
     start_time=MPI_Wtime()
-    tend=tend+time    
+    tend=tend+time
 !    if (flag_mpi.eq.0 .or. my_rank.eq.1) print *,"time",start_time,tend,dtout
     call initialize_IOT(dtout,tend,output_type)
   end subroutine restart
@@ -488,7 +488,7 @@ endif
     write(step_char,"(i4.4)")flag_restart
     nvar=ix
     if(ndim.ge.2)nvar=nvar*jx
-    if(ndim.ge.3)nvar=nvar*kx    
+    if(ndim.ge.3)nvar=nvar*kx
 
     call set_initial_out
     if(flag_mhd.eq.1) then
@@ -498,7 +498,7 @@ endif
        enddo
     endif
 
-    if(flag_pip.eq.1.or.flag_mhd.eq.0) then       
+    if(flag_pip.eq.1.or.flag_mhd.eq.0) then
        do i=1,nvar_h
           call dacget(mf_h(i,1),trim(indir)//step_char//trim(file_h(i))//cno,nvar,&
                U_h(:,:,:,mf_h(i,2)))
@@ -538,7 +538,7 @@ endif
     if(my_rank.eq.0) then
        call copy_time(mf_t,trim(indir)//'t.dac.0000',trim(outdir)//'t.dac.0000',flag_restart+1)
     endif
-    
+
   end subroutine reread_variables
 
 
@@ -565,7 +565,7 @@ endif
     enddo
     i=tmp
     !-----------------------------------------------
-!    if(present(restart)) then 
+!    if(present(restart)) then
     do i=1,n_read
        read(idf)var(1+(i-1)*read_size:read_size*i)
     enddo
@@ -591,11 +591,11 @@ endif
        times(i)=time_tmp
     enddo
     close(idf)
-    
+
     call dacdef0s(idf,out_file,6,0)
     do i=1,start_step
        write(idf)times(i)
-    end do    
+    end do
     close(idf)
 
   end subroutine copy_time
@@ -618,8 +618,8 @@ endif
     enddo
     close(idf)
   end subroutine get_time
-  
-  
+
+
   subroutine dacdef1d(idf,file,mtype,in)
     integer,intent(in)::idf,mtype,in
     character*(*) file
@@ -655,11 +655,11 @@ endif
        write(idf)0
        write(idf)mtype
        write(idf)4
-       write(idf)ix,jx,kx,-1       
+       write(idf)ix,jx,kx,-1
     else
-       
+
        open(idf,file=file,form='unformatted',position='append')
-    endif 
+    endif
   end subroutine dacdef3s
 
 
@@ -681,7 +681,7 @@ endif
        flag_stop=1
     endif
     if (flag_mhd.eq.1) then
-       if(sum(U_m*0).ne.0)then          
+       if(sum(U_m*0).ne.0)then
           o_count=0
           print *,"NAN Appear"
           do k=1,kx;do j=1,jx;do i=1,ix
@@ -692,7 +692,7 @@ endif
                 o_count=o_count+1
              endif
           enddo;enddo;enddo
-          flag_stop=1       
+          flag_stop=1
        endif
     else
        if(sum(U_h*0).ne.0)then
@@ -707,11 +707,11 @@ endif
           enddo;enddo;enddo
           flag_stop=1
        endif
-    endif    
+    endif
     if(flag_mpi.eq.1) then
        call mpi_allreduce(flag_stop,tmp_stop,1,mpi_integer,MPI_MAX, &
             mpi_comm_world,ierr)
        flag_stop=tmp_stop
-    endif   
+    endif
   end subroutine stop_sim
 end module io_rot

--- a/MPI_rot.f90
+++ b/MPI_rot.f90
@@ -1,55 +1,67 @@
 module mpi_rot
   use globalvar,only:total_prc,my_rank,nvar_h,nvar_m,mpi_siz,mpi_pos,margin,&
        ix,jx,kx,ndim,flag_mpi_split,neighbor,U_h,U_m,flag_mhd,flag_pip,&
-       cno,vmpi,flag_mpi,flag_bnd
+       cno,vmpi,flag_mpi,flag_bnd, &
+       dimsFile, ig
   implicit none
   include "mpif.h"
   integer ierr
   integer status(6)
 contains
-  subroutine set_mpi    
+  subroutine set_mpi
+    integer i
     !charm for MPI
     call mpi_init(ierr)
     call mpi_comm_size(MPI_COMM_WORLD,total_prc,ierr)
-    call mpi_comm_rank(MPI_COMM_WORLD,my_rank,ierr)   
- 
+    call mpi_comm_rank(MPI_COMM_WORLD,my_rank,ierr)
+
     if(flag_mpi.eq.0 .or.my_rank.eq.0) print *,"total cpu",total_prc
     vmpi=nvar_h+nvar_m
     write(cno,"(i4.4)")my_rank
-!   print *,"TOT",total_prc,my_rank,cno 
-   if(total_prc.eq.1) then
-       mpi_siz(:)=1
-       mpi_pos(:)=0       
+    !   print *,"TOT",total_prc,my_rank,cno
+    if(total_prc.eq.1) then
+      mpi_siz(:)=1
+      mpi_pos(:)=0
     else
-       call set_mpi_pos
+      call set_mpi_pos
     endif
-    ix=(ix-2*margin(1))/mpi_siz(1)+2*margin(1)
-    jx=(jx-2*margin(2))/mpi_siz(2)+2*margin(2)
-    kx=(kx-2*margin(3))/mpi_siz(3)+2*margin(3)    
+
+    ! store full ranges + margins for use in write-IO
+    dimsFile(1:3) = [ix, jx, kx]
+    ! compute # of grid-points for individual process
+    do i=1,3
+      ig(i) = (dimsFile(i)-2*margin(i))/mpi_siz(i)+2*margin(i)
+      ! Add excess grid-points from uneven splitting to last block along dimension
+      if (mpi_pos(i) .eq. (mpi_siz(i)-1)) then
+        ig(i) = ig(i) + mod(dimsFile(i)-2*margin(i), mpi_siz(i))
+      end if
+    end do
+    ! replace _x range values with those for the process
+    ix=ig(1); jx=ig(2); kx=ig(3))
   end subroutine set_mpi
-    
+
   subroutine set_mpi_pos
     integer n0,tmp!,tmp2,n2,n3
     integer n!ixy,iyz,izx
     if(mpi_siz(1)*mpi_siz(2)*mpi_siz(3).eq.0  &
-         .or. mpi_siz(1)*mpi_siz(2)*mpi_siz(3).ne.total_prc) then    
-       select case(flag_mpi_split)    
+         .or. mpi_siz(1)*mpi_siz(2)*mpi_siz(3).ne.total_prc) then
+       select case(flag_mpi_split)
        !1D domain decomposition
        case(1)
           mpi_siz(1)=total_prc
           mpi_siz(2)=1
-          mpi_siz(3)=1          
+          mpi_siz(3)=1
        !n-dimensional decomposition
        case(2)
           call set_domain_equally(mpi_siz(1),mpi_siz(2),mpi_siz(3),3,total_prc)
-       !adjust 
+       !adjust
        case(3)
           n0=0
           do n=1,3
              if(mpi_siz(n).eq.0) n0=n0+1
           enddo
           select case(n0)
-          case(1)             
+          case(1)
              do n=1,3
                 if(mpi_siz(n).eq.0) mpi_siz(n)=total_prc/ &
                      (mpi_siz(mod(n,3)+1)*mpi_siz(mod(n+1,3)+1))

--- a/MPI_rot.f90
+++ b/MPI_rot.f90
@@ -37,7 +37,7 @@ contains
       end if
     end do
     ! replace _x range values with those for the process
-    ix=ig(1); jx=ig(2); kx=ig(3))
+    ix=ig(1); jx=ig(2); kx=ig(3)
   end subroutine set_mpi
 
   subroutine set_mpi_pos

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ MOD_FILES = util_rot.mod globalvar.mod parameters.mod \
 	boundary_rot.mod solver_rot.mod matrix_rot.mod initial_rot.mod  procedures.mod
 
 #FC = gfortran
-FC = mpif90 -O2
+FC = h5pfc
 #FC = mpif90-mpich-mp -O2
 #FC = mpif90-mpich-mp
 
@@ -34,21 +34,20 @@ FFLAGS = -O2
 #FFLAGS = 
 LDFLAGS =
 LIB_DIR=.
-#DEBUG = -g -pg 
+#DEBUG = -g -pg
 #DEBUG= -ffpe-trap=invalid,zero,overflow -fbacktrace -fbounds-check -g
 #DEBUG= -ffpe-trap=invalid,overflow -fbacktrace -fbounds-check -g
 #DEBUG= -fbacktrace -fbounds-check -g
 #DEBUG= -fbacktrace -g
-DEBUG= 
+DEBUG=
 
 .SUFFIXES : .o .f90
 .f90.o:
-	${FC} ${FFLAGS} ${DEBUG} -c $< 
+	${FC} ${FFLAGS} ${DEBUG} -c $<
 
 
 ${TARGET} : ${OBJECTS}
-	${FC} ${DEBUG} ${LDFLAGS} -o $@ ${OBJECTS} \
-	-L$(LIB_DIR) 
+	${FC} ${DEBUG} -L$(LIB_DIR) ${LDFLAGS} -o $@ ${OBJECTS}
 #	rm ${OBJECTS} ${MOD_FILES}
 clean:
 	rm ${TARGET} ${OBJECTS} ${MOD_FILES}
@@ -57,4 +56,4 @@ datatidy:
 	rm Data/*
 
 print_vars:
-	@echo "FC='${FC}'" 
+	@echo "FC='${FC}'"

--- a/Model_rot.f90
+++ b/Model_rot.f90
@@ -368,7 +368,6 @@ subroutine get_parameters
 
  !Allocate the array sizes
  subroutine allocate_vars
-   ig(1)=ix ; ig(2)=jx ; ig(3)=kx   
    if(flag_mpi.eq.0 .or.my_rank.eq.0) print *,"total grid :",ix,jx,kx
    allocate(x(ix),dx(ix),y(jx),dy(jx),z(kx),dz(kx),dsc(max(ix,jx,kx),3),&
         dxc(ix),dyc(jx),dzc(kx))


### PR DESCRIPTION
This set of code changes involves refactoring the I/O code in `IO_rot.f90`:
- It now utilizes the Fortran parallel HDF5 library rather than writing data to IDL compliant binary files. 
- The coordinates and physical variables across all grid-points are saved to a single file, once per time step, greatly reducing the number of files produced in a given simulation. 
- Because the out file format has changed, the subroutines used in restarting a simulation have also been updated to read HDF5 files. 
- The simulation time for a given time-step is now saved within that output file, so there is no longer a need for a separate time series file for record keeping.
- _Bug Fix_: Change the grid-point allocation code in `MPI_rot.f90`, as it wasn't allocation all grid points to a block if the # wasn't evenly divisible by the number of MPI processes.